### PR TITLE
Updates

### DIFF
--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -34,12 +34,6 @@ jobs:
         with:
           terraform_version: 1.6.5 # Replace with your desired Terraform version
 
-      - name: Import Database into Terraform
-        run: terraform import aws_db_instance.terraform_blog_example terraform-blog-example
-
-      - name: Import Parameter group into Terraform
-        run: terraform import aws_db_parameter_group.terraform_blog_example terraform-blog-example-pg
-
       - name: Initialize Terraform
         run: terraform init
 

--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Initialize Terraform
         run: terraform init
 
+      - name: Import Database into Terraform
+        run: terraform import aws_db_instance.terraform_blog_example terraform-blog-example
+
+      - name: Import Parameter group into Terraform
+        run: terraform import aws_db_parameter_group.terraform_blog_example terraform-blog-example-pg
+
       - name: Apply Terraform changes
         # CAUTION: -auto-approve may override changes to the infra
         # that are not saved in the terraform files 

--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -55,8 +55,8 @@ jobs:
         if: steps.verify_diff.outputs.changed == 'true'
         run: |
           git status
-          git config user.email "priyankbhandia@gmail.com"
-          git config user.name "priyank96"
+          git config user.email "name@mail.com"  # Github email
+          git config user.name "user"  # Github username
           git add db_params.tf
           git commit -m "AI knob updates"
           git push

--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -34,14 +34,14 @@ jobs:
         with:
           terraform_version: 1.6.5 # Replace with your desired Terraform version
 
-      - name: Initialize Terraform
-        run: terraform init
-
       - name: Import Database into Terraform
         run: terraform import aws_db_instance.terraform_blog_example terraform-blog-example
 
       - name: Import Parameter group into Terraform
         run: terraform import aws_db_parameter_group.terraform_blog_example terraform-blog-example-pg
+
+      - name: Initialize Terraform
+        run: terraform init
 
       - name: Apply Terraform changes
         # CAUTION: -auto-approve may override changes to the infra

--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -46,7 +46,13 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Check if there are any changes
+          id: verify_diff
+          run: |
+            git diff --quiet . || echo "changed=true" >> $GITHUB_OUTPUT
+
       - name: Commit changes
+        if: steps.verify_diff.outputs.changed == 'true'
         run: |
           git status
           git config user.email "priyankbhandia@gmail.com"

--- a/.github/workflows/daily_update.yml
+++ b/.github/workflows/daily_update.yml
@@ -47,9 +47,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Check if there are any changes
-          id: verify_diff
-          run: |
-            git diff --quiet . || echo "changed=true" >> $GITHUB_OUTPUT
+        id: verify_diff
+        run: |
+          git diff --quiet . || echo "changed=true" >> $GITHUB_OUTPUT
 
       - name: Commit changes
         if: steps.verify_diff.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # terraform-blog-example
-The draft for the blog can be found [here](https://docs.google.com/document/d/1ctctITadyz77CtTvll_U6-HAMN5C6LSQKASPd_MVbjU/edit).
-
 Example code for using the Public API &amp; GitHub Actions to update knobs through Terraform

--- a/db_params.tf
+++ b/db_params.tf
@@ -68,7 +68,7 @@ resource "aws_db_parameter_group" "terraform_blog_example" {
   }
   parameter {
     name  = "wal_writer_delay"
-    value = "200"
+    value = "250"
   }
   parameter {
     name  = "work_mem"

--- a/db_params.tf
+++ b/db_params.tf
@@ -68,7 +68,7 @@ resource "aws_db_parameter_group" "terraform_blog_example" {
   }
   parameter {
     name  = "wal_writer_delay"
-    value = "250"
+    value = "200"
   }
   parameter {
     name  = "work_mem"

--- a/db_params.tf
+++ b/db_params.tf
@@ -1,5 +1,10 @@
 # AWS RDS PostgreSQL Parameter Group Configuration
 
+import {
+  to = aws_db_parameter_group.terraform_blog_example
+  id = "terraform-blog-example-pg"
+}
+
 resource "aws_db_parameter_group" "terraform_blog_example" {
   name   = "terraform-blog-example-pg" # Name of the DB parameter group
   family = "postgres15"                # Database family (PostgreSQL 15.x in this case)

--- a/db_params.tf
+++ b/db_params.tf
@@ -16,59 +16,59 @@ resource "aws_db_parameter_group" "terraform_blog_example" {
 
   parameter {
     name  = "autovacuum_vacuum_cost_delay"
-    value = "2"
+    value = "7"
   }
   parameter {
     name  = "autovacuum_vacuum_scale_factor"
-    value = "0.1"
+    value = "0.12"
   }
   parameter {
     name  = "autovacuum_vacuum_threshold"
-    value = "50"
+    value = "439"
   }
   parameter {
     name  = "bgwriter_delay"
-    value = "200"
+    value = "90"
   }
   parameter {
     name  = "bgwriter_lru_maxpages"
-    value = "100"
+    value = "442"
   }
   parameter {
     name  = "bgwriter_lru_multiplier"
-    value = "2"
+    value = "2.89"
   }
   parameter {
     name  = "checkpoint_completion_target"
-    value = "0.9"
+    value = "0.81"
   }
   parameter {
     name  = "default_statistics_target"
-    value = "100"
+    value = "762"
   }
   parameter {
     name  = "effective_cache_size"
-    value = "47626"
+    value = "53043"
   }
   parameter {
     name  = "effective_io_concurrency"
-    value = "1"
+    value = "213"
   }
   parameter {
     name  = "max_wal_size"
-    value = "2048"
+    value = "2410"
   }
   parameter {
     name  = "random_page_cost"
-    value = "4"
+    value = "1.6"
   }
   parameter {
     name  = "temp_buffers"
-    value = "1024"
+    value = "2452"
   }
   parameter {
     name  = "wal_writer_delay"
-    value = "250"
+    value = "452"
   }
   parameter {
     name  = "work_mem"

--- a/db_params.tf
+++ b/db_params.tf
@@ -16,55 +16,55 @@ resource "aws_db_parameter_group" "terraform_blog_example" {
 
   parameter {
     name  = "autovacuum_vacuum_cost_delay"
-    value = "7"
+    value = "2"
   }
   parameter {
     name  = "autovacuum_vacuum_scale_factor"
-    value = "0.12"
+    value = "0.1"
   }
   parameter {
     name  = "autovacuum_vacuum_threshold"
-    value = "439"
+    value = "50"
   }
   parameter {
     name  = "bgwriter_delay"
-    value = "90"
+    value = "200"
   }
   parameter {
     name  = "bgwriter_lru_maxpages"
-    value = "442"
+    value = "100"
   }
   parameter {
     name  = "bgwriter_lru_multiplier"
-    value = "2.89"
+    value = "2"
   }
   parameter {
     name  = "checkpoint_completion_target"
-    value = "0.81"
+    value = "0.9"
   }
   parameter {
     name  = "default_statistics_target"
-    value = "762"
+    value = "100"
   }
   parameter {
     name  = "effective_cache_size"
-    value = "53043"
+    value = "47626"
   }
   parameter {
     name  = "effective_io_concurrency"
-    value = "213"
+    value = "1"
   }
   parameter {
     name  = "max_wal_size"
-    value = "2410"
+    value = "2048"
   }
   parameter {
     name  = "random_page_cost"
-    value = "1.6"
+    value = "4"
   }
   parameter {
     name  = "temp_buffers"
-    value = "2452"
+    value = "1024"
   }
   parameter {
     name  = "wal_writer_delay"

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,10 @@ provider "aws" {
 # Set environment variable `TF_VAR_db_password="your_secure_password"`
 variable "db_password" {}
 
+import {
+  to = aws_db_instance.terraform_blog_example
+  id = "terraform-blog-example"
+}
 
 # AWS RDS PostgreSQL instance creation using Terraform
 resource "aws_db_instance" "terraform_blog_example" {

--- a/update_parameters.py
+++ b/update_parameters.py
@@ -55,6 +55,8 @@ try:
 
         print(f"KNOB_RECOMMENDATIONS = {json.dumps(knob_recommendations, indent=4, default=str)}\n")
 
+        # We have some new knob values from OtterTune which we need to update
+        # in our terraform file
         if len(knob_recommendations) > 0:
             with open(terraform_file_path, 'r') as file:
                 terraform_config = file.read()
@@ -68,6 +70,13 @@ try:
                 line = config_lines[i]
 
                 # Check if the line contains the parameter definition
+                # parameter definitions look like:
+                # parameter {
+                #  name = "param_name"
+                #  value = "param_value"
+                # }
+                # Note: This script will only update those parameters that are present
+                # in the parameter configuration file, other recommendations will be ignored
                 if line.strip().startswith("parameter {"):
                     # Extract the parameter name and value
                     param_name = None
@@ -84,6 +93,7 @@ try:
                         line = config_lines[i]
                         i += 1
 
+                    # the parameter in the terraform configuration has a new recommended value
                     if param_name in knob_recommendations:
                         # Replace the parameter value with the new value
                         param_value = knob_recommendations[param_name]


### PR DESCRIPTION
# What
From the  [previous PR](https://github.com/ottertune/terraform-blog-example/pull/1):
- AWS credentials: Fixed the issue to import the AWS credentials correctly in the `daily_update.yaml`
- No new recommendations: The files are committed and pushed only if there are changes
- Commit Changes when needed only: The files are committed only after the terraform changes are applied

New Changes:
- Added an import step in `daily_update.yaml` to import existing database and parameter group into local terraform state. This gives the expected behaviour of updating the resources instead of trying to create them again.


# Test Plan
Will keep the database and agent around for a few more days to see if created knob recommendations are applied correctly.
## Updates from Github Actions are Applied to the Database:
Changed WAL delay to 250 and committed.
The Change was picked up by the Action:
![image](https://github.com/ottertune/terraform-blog-example/assets/14112602/fdd282fa-04ff-4c45-9135-5cac8733af51)

 and reflected correctly in AWS:
![image](https://github.com/ottertune/terraform-blog-example/assets/14112602/f7b8bc8a-f0eb-4b96-825a-43db586e33f0)

## Knob Recommendations from Public API are applied
Job takes available updates and applies: https://github.com/ottertune/terraform-blog-example/actions/runs/7188909748/job/19579477515
![image](https://github.com/ottertune/terraform-blog-example/assets/14112602/ae814b27-98d3-4fb4-a49a-493212dae00b)

![image](https://github.com/ottertune/terraform-blog-example/assets/14112602/85680f2a-b6d6-405b-9c1c-8da037425b8b)

![image](https://github.com/ottertune/terraform-blog-example/assets/14112602/7a3af946-32d0-4490-9e50-81947d0043c8)

